### PR TITLE
Refactor measurement update to QR-based square-root form

### DIFF
--- a/eskf/eskf.hpp
+++ b/eskf/eskf.hpp
@@ -183,8 +183,7 @@ public:
         stacked_measurement.bottomRows<12>() = W;
 
         Eigen::HouseholderQR<Eigen::Matrix<double, 18, 6>> qr(stacked_measurement);
-        Eigen::Matrix<double, 18, 6> transformed_measurement = qr.householderQ().adjoint() * stacked_measurement;
-        Eigen::Matrix<double, 6, 6> T = transformed_measurement.topRows<6>();
+        Eigen::Matrix<double, 6, 6> T = qr.matrixQR().topRows<6>();
         T.template triangularView<Eigen::StrictlyLower>().setZero();
 
         Eigen::Matrix<double, 6, 12> Y = T.triangularView<Eigen::Upper>().solve(W.transpose());


### PR DESCRIPTION
## Summary
- replace the measurement update with a QR-based square-root formulation using the measurement noise square root and LHᵀ
- compute the Kalman gain and state correction via triangular solves without explicitly forming S or its inverse
- update the covariance square root by applying the QR orthogonal transform to the stacked prior factor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22dca74d48322a57e0e729cccb125